### PR TITLE
fix: Add NULL check for pGraph in cypher_execute functions

### DIFF
--- a/src/cypher/cypher-executor-sql.c
+++ b/src/cypher/cypher-executor-sql.c
@@ -43,10 +43,18 @@ static void cypherExecuteSqlFunc(
     sqlite3_result_error(context, "cypher_execute() requires exactly one argument", -1);
     return;
   }
-  
+
   zQuery = (const char*)sqlite3_value_text(argv[0]);
   if( !zQuery ) {
     sqlite3_result_null(context);
+    return;
+  }
+
+  /* Check that graph virtual table has been initialized */
+  if( !pGraph ) {
+    sqlite3_result_error(context,
+      "Graph virtual table not initialized. Create a graph table first using: "
+      "CREATE VIRTUAL TABLE graph USING graph();", -1);
     return;
   }
   
@@ -177,7 +185,15 @@ static void cypherExecuteExplainSqlFunc(
     sqlite3_result_null(context);
     return;
   }
-  
+
+  /* Check that graph virtual table has been initialized */
+  if( !pGraph ) {
+    sqlite3_result_error(context,
+      "Graph virtual table not initialized. Create a graph table first using: "
+      "CREATE VIRTUAL TABLE graph USING graph();", -1);
+    return;
+  }
+
   /* Parse and plan the query (same as cypher_execute) */
   pParser = cypherParserCreate();
   if( !pParser ) {
@@ -283,9 +299,17 @@ static void cypherTestExecuteSqlFunc(
     sqlite3_result_error(context, "cypher_test_execute() takes no arguments", -1);
     return;
   }
-  
+
+  /* Check that graph virtual table has been initialized */
+  if( !pGraph ) {
+    sqlite3_result_error(context,
+      "Graph virtual table not initialized. Create a graph table first using: "
+      "CREATE VIRTUAL TABLE graph USING graph();", -1);
+    return;
+  }
+
   /* Execute a simple test query */
-  zResult = cypherExecuteTestQuery(sqlite3_context_db_handle(context), 
+  zResult = cypherExecuteTestQuery(sqlite3_context_db_handle(context),
                                   "MATCH (n) RETURN n");
   
   if( zResult ) {


### PR DESCRIPTION
## Summary

- Adds NULL validation for `pGraph` before use in all three Cypher SQL functions
- Returns descriptive SQLite error instead of segfaulting when graph table not initialized
- Affected functions: `cypher_execute()`, `cypher_execute_explain()`, `cypher_test_execute()`

## Root Cause

The global `pGraph` pointer (defined in `src/graph.c`) is `NULL` until `CREATE VIRTUAL TABLE graph USING graph()` is executed. If Cypher functions are called before table creation, the NULL pointer is dereferenced causing a segfault.

## Fix

Added early NULL check with user-friendly error message:

```c
if( !pGraph ) {
  sqlite3_result_error(context,
    "Graph virtual table not initialized. Create a graph table first using: "
    "CREATE VIRTUAL TABLE graph USING graph();", -1);
  return;
}
```

## Test Plan

- [ ] Verify calling `cypher_execute()` before table creation returns error (not crash)
- [ ] Verify calling `cypher_execute_explain()` before table creation returns error
- [ ] Verify calling `cypher_test_execute()` before table creation returns error
- [ ] Verify normal operation still works after creating graph table

Fixes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)